### PR TITLE
Set a branch name to "main" when a tag is pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,9 @@ jobs:
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         with:
-          args: >
+          args: >-
             -Dsonar.projectVersion=${{ (startsWith(github.ref, 'refs/tags/') && github.ref_name) || '' }}
+            -Dsonar.branch.name=${{ (startsWith(github.ref, 'refs/tags/') && 'main') || github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
When a tag is pushed, sonar-scanner badly  set a branch name to "refs/tags/vX.Y.Z".
It's not desirable and the branch name should be "main".